### PR TITLE
Gif/Gfycat - added note about firewall setup

### DIFF
--- a/source/administration/config-settings.rst
+++ b/source/administration/config-settings.rst
@@ -2522,6 +2522,10 @@ Enable GIF Picker
 | This feature's ``config.json`` setting is ``"EnableGifPicker": false`` with options ``true`` and ``false`` for above settings respectively.                          |
 +----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+.. note::
+
+  Mattermost deployments restricted to access behind a firewall must open port 443 to https://api.gfycat.com/v1 (for all request types) for this feature to work
+
 Gfycat API Key
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 When blank, uses the default API key provided by Gfycat. Alternatively, a unique API key can be requested at https://developers.gfycat.com/signup/#/. Enter the client ID you receive via email to this field. 


### PR DESCRIPTION
Customers behind a firewall require firewall settings to be opened up for this integration to work.